### PR TITLE
fix(vercel): import pre-built entry.mjs with page manifest to fix FUN…

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,10 @@
 import { handle } from 'hono/vercel'
-import { app } from '../pages/+server'
+// Import from the Vite-built entry — this file contains:
+// 1. The full Hono app with all API routes
+// 2. The Vike SSR middleware
+// 3. The page manifest (setGlobalContext_prodBuildEntry)
+// The post-build script (scripts/patch-vercel-entry.mjs) patches it to export { app }.
+import { app } from '../dist/server/entry.mjs'
 
 // Vercel Serverless Function entry point
-// Using Hono's Vercel adapter to properly bridge Node's req/res to Web Standards
 export default handle(app)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/patch-vercel-entry.mjs",
     "prod": "vike build && vike preview",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/scripts/patch-vercel-entry.mjs
+++ b/scripts/patch-vercel-entry.mjs
@@ -1,0 +1,28 @@
+/**
+ * Post-build script: Patches dist/server/entry.mjs to export the Hono `app`
+ * so that api/index.ts (Vercel Serverless Function) can import and wrap it.
+ *
+ * Vike's build bundles the entire +server.ts into entry.mjs including the
+ * Hono app and all page manifests, but it ends with `export {};`.
+ * This script replaces that empty export with `export { app };`.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const entryPath = resolve('dist/server/entry.mjs')
+
+let content = readFileSync(entryPath, 'utf-8')
+
+// Replace the final `export {};` with `export { app };`
+const needle = 'export {};'
+const lastIndex = content.lastIndexOf(needle)
+
+if (lastIndex === -1) {
+  console.warn('[patch-vercel-entry] Could not find "export {};" in entry.mjs — skipping patch')
+  process.exit(0)
+}
+
+content = content.slice(0, lastIndex) + 'export { app };' + content.slice(lastIndex + needle.length)
+
+writeFileSync(entryPath, content, 'utf-8')
+console.log('[patch-vercel-entry] ✅ Patched entry.mjs to export { app }')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import vike from 'vike/plugin'
-import { vercel } from 'vite-plugin-vercel/vite'
+// vite-plugin-vercel removed: @vite-plugin-vercel/vike only supports Vite ^5||^6, not Vite 8
+// We use a post-build patch + api/index.ts approach instead (see scripts/patch-vercel-entry.mjs)
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -46,7 +47,7 @@ export default defineConfig({
   plugins: [
     react(),
     vike({}),
-    vercel(),
+
   ],
 
   ssr: {


### PR DESCRIPTION
…CTION_INVOCATION_FAILED

Root cause: api/index.ts was importing source pages/+server.ts which meant Vike's renderPage() never had the page manifest loaded (setGlobalContext_prodBuildEntry only runs in the Vite-built entry.mjs).

Also: @vite-plugin-vercel/vike only supports Vite ^5||^6, not Vite 8, so it was silently generating empty .vercel/output.

Fix:
- Post-build script patches entry.mjs to export { app }
- api/index.ts imports from dist/server/entry.mjs (pre-built)
- Removed non-functional vite-plugin-vercel from vite.config.ts